### PR TITLE
Fix uncaught error when loading dashboards with slices associated with deleted dataset

### DIFF
--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -237,6 +237,7 @@ class Dashboard(  # pylint: disable=too-many-instance-attributes
                 # Filter out unneeded fields from the datasource payload
                 datasource.uid: datasource.data_for_slices(slices)
                 for datasource, slices in datasource_slices.items()
+                if datasource
             },
         }
 


### PR DESCRIPTION
### SUMMARY
Fix uncaught error when loading dashboards with slices associated with deleted dataset
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before 
![image](https://user-images.githubusercontent.com/9404600/104663436-d63ca280-5681-11eb-9f5a-14c72b85a058.png)

After 
![image (1)](https://user-images.githubusercontent.com/9404600/104661427-57de0180-567d-11eb-9edd-ba026bede40c.png)
![image (2)](https://user-images.githubusercontent.com/9404600/104661435-5ad8f200-567d-11eb-8fa9-29d05342e901.png)



### TEST PLAN
<!--- What steps should be taken to verify the changes -->
1. Run superset locally
2. Delete the dataset of a chart that belongs to a dashboard
3. Open the dashboard which includes the chart

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
